### PR TITLE
feat: support non-standard markdownDescription property

### DIFF
--- a/internal/jsonschema/schema.go
+++ b/internal/jsonschema/schema.go
@@ -40,6 +40,7 @@ type Schema struct {
 	ID                    string             `json:"$id,omitempty"`
 	If                    *Schema            `json:"if,omitempty"`
 	Items                 *Schema            `json:"items,omitempty"`
+	MarkdownDescription   string             `json:"markdownDescription,omitempty"`
 	MaxContains           int                `json:"maxContains,omitempty"`
 	Maximum               float64            `json:"maximum,omitempty"`
 	MaxItems              int                `json:"maxItems,omitempty"`
@@ -123,6 +124,16 @@ func (s *Schema) Clone() (*Schema, error) {
 		return nil, err
 	}
 	return s.Context.parse(doc, s.Parent)
+}
+
+// DescriptionMarkdown returns the schema description formatted as Markdown,
+// Will prioritize the non-standard `markdownDescription` attribute if present,
+// otherwise uses `description`.
+func (s *Schema) DescriptionMarkdown() string {
+	if s.MarkdownDescription != "" {
+		return s.MarkdownDescription
+	}
+	return s.Description
 }
 
 func (s *Schema) EntityName() string {
@@ -259,6 +270,8 @@ func (s *Schema) Merge(other *Schema) {
 			s.If = other.If
 		case "items":
 			s.Items = other.Items
+		case "markdownDescription":
+			s.MarkdownDescription = other.MarkdownDescription
 		case "maxContains":
 			s.MaxContains = other.MaxContains
 		case "maximum":

--- a/internal/jsonschema/schema_test.go
+++ b/internal/jsonschema/schema_test.go
@@ -93,6 +93,27 @@ func TestSchema_RefURI(t *testing.T) {
 	)
 }
 
+func TestSchema_DescriptionMarkdown(t *testing.T) {
+	require := require.New(t)
+
+	// Defaults to empty string.
+	schema := Schema{}
+	require.Equal("", schema.DescriptionMarkdown())
+
+	// Uses `.Description` if present.
+	schema = Schema{
+		Description: "This _could_ be Markdown",
+	}
+	require.Equal("This _could_ be Markdown", schema.DescriptionMarkdown())
+
+	// Uses `.MarkdownDescription` if present.
+	schema = Schema{
+		Description:         "This _could_ be Markdown",
+		MarkdownDescription: "This **is** Markdown",
+	}
+	require.Equal("This **is** Markdown", schema.DescriptionMarkdown())
+}
+
 func TestSchema_EntityName(t *testing.T) {
 	require := require.New(t)
 
@@ -252,6 +273,7 @@ func TestSchema_Merge(t *testing.T) {
 			"$id":                   true,
 			"if":                    true,
 			"items":                 true,
+			"markdownDescription":   true,
 			"maxContains":           true,
 			"maximum":               true,
 			"maxItems":              true,

--- a/internal/jsonschema/templates/markdown.tpl.md
+++ b/internal/jsonschema/templates/markdown.tpl.md
@@ -16,32 +16,30 @@
 | -------- | ---- | -------- | ------- | ----------- |
 {{ $propParent := . -}}
 {{ range $key, $prop := $propParent.Properties -}}
-| `{{ $key }}` | {{ $prop.TypeInfoMarkdown }} | {{ if $propParent.RequiredKey $key }}✅{{ end }} | {{ $prop.Default }} | {{ $prop.Description | toHTML }}{{ template "ConstTpl" $prop.Const }}{{ template "EnumTpl" $prop.EnumMarkdown }}{{ template "ExamplesTpl" $prop.ExamplesMarkdown }} |
-{{ end }}
+| `{{ $key }}` | {{ $prop.TypeInfoMarkdown }} | {{ if $propParent.RequiredKey $key }}✅{{ end }} | {{ $prop.Default }} | {{ $prop.DescriptionMarkdown | toHTML }}{{ template "ConstTpl" $prop.Const }}{{ template "EnumTpl" $prop.EnumMarkdown }}{{ template "ExamplesTpl" $prop.ExamplesMarkdown }} |
+{{ end -}}
 {{ end -}}
 {{ end -}}
 
 # {{ .EntityName }}
 
-{{ .Description }}
+{{ .DescriptionMarkdown }}
 
 ## {{ .EntityName }} Properties
 
-{{ template "PropertiesTpl" . -}}
-
+{{ template "PropertiesTpl" . }}
 {{ range $key, $def := .Definitions -}}
 {{ if $def.Enum }}{{ continue }}{{ end -}}
 
 ## {{ $def.EntityName }}
 
-{{ $def.Description }}
+{{ $def.DescriptionMarkdown }}
 
 {{ if $def.Properties -}}
 
 ### {{ $def.EntityName }} Properties
 
-{{ template "PropertiesTpl" $def -}}
-
+{{ template "PropertiesTpl" $def }}
 {{ end -}}
 
 {{ if $def.OneOf -}}


### PR DESCRIPTION
Adds support for the non-standard `markdownDescription` property. This property is primarily used by a few LSP language servers (JSON, YAML, etc) to render documentation when hovering over properties in IDEs. They treat `description` as plain text and escape any markdown present. Schema authors that want rendered markdown must also include `markdownDescription`.

For now, schemadoc is going to render everything as markdown. I suspect few schemas are bothering with duplicating their descriptions across two props. But for those that _do_, we should support rendering `markdownDescription` if present.
