### PR TITLE
feat: show property key in example yaml

### DIFF
--- a/internal/jsonschema/context.go
+++ b/internal/jsonschema/context.go
@@ -164,8 +164,8 @@ func resolveSubSchemas(schema *Schema) (*Schema, error) {
 		*subSchema = *tmp
 	}
 
-	for _, subSchema := range schema.Properties {
-		// subSchema.Key = key
+	for key, subSchema := range schema.Properties {
+		subSchema.Key = key
 		subSchema.Parent = schema
 		tmp, err := resolveRef(subSchema)
 		if err != nil {

--- a/internal/jsonschema/schema.go
+++ b/internal/jsonschema/schema.go
@@ -177,27 +177,27 @@ func (s *Schema) EnsureDocument() {
 	}
 }
 
-// EnumMarkdown returns the enum and enum descriptions
-// formatted as a markdown list.
-func (s *Schema) EnumMarkdown() string {
+// EnumMarkdownItems returns the .Enum items formatted as Markdown.
+// If .Const is present, will treat that as a virtual enum of one.
+func (s *Schema) EnumMarkdownItems() []string {
+	// Const takes priority...
+	if s.Const.IsSet() {
+		return []string{"`" + s.Const.JSONString() + "`"}
+	}
+	// Otherwise use Enum
 	items := []string{}
-
 	for idx, enum := range s.Enum {
 		desc := ""
 		if idx < len(s.EnumDescriptions) {
 			desc = s.EnumDescriptions[idx]
 		}
-		item := "- `" + enum.String() + "`"
+		item := "`" + enum.JSONString() + "`"
 		if desc != "" {
 			item += ": " + desc
 		}
 		items = append(items, item)
 	}
-
-	if len(items) == 0 {
-		return ""
-	}
-	return strings.Join(items, "\n")
+	return items
 }
 
 // YAMLExamples returns the examples formatted as YAML.
@@ -493,6 +493,10 @@ func (a Any) MarshalJSON() ([]byte, error) {
 
 func (a *Any) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &a.value)
+}
+
+func (a Any) IsSet() bool {
+	return a.value != nil
 }
 
 func (a Any) String() string {

--- a/internal/jsonschema/templates/markdown.tpl.md
+++ b/internal/jsonschema/templates/markdown.tpl.md
@@ -34,7 +34,7 @@ Examples:
 {{ range $example := . -}}
 
 ```yaml
-{{ $example.YAMLString }}
+{{ $example }}
 ```
 
 {{ end -}}
@@ -85,8 +85,6 @@ Examples:
 | {{ $prop.TypeInfoMarkdown }} | {{ if $root.RequiredKey $key }}✅{{ else }}➖{{ end }} | {{ if $prop.Enum }}✅{{ else }}➖{{ end }} | {{ $prop.Default.JSONString | wrapCode | default "➖" }} |
 
 {{ template "DescriptionTpl" $prop.DescriptionMarkdown }}
-{{ template "ConstTpl" $prop.Const.String }}
-{{ template "EnumTpl" $prop.EnumMarkdown }}
-{{ template "ExamplesTpl" $prop.Examples }}
+{{ template "ExamplesTpl" $prop.YAMLExamples }}
 
 {{ end -}}

--- a/internal/jsonschema/templates/markdown.tpl.md
+++ b/internal/jsonschema/templates/markdown.tpl.md
@@ -1,13 +1,3 @@
-{{ define "ConstTpl" -}}
-{{ if . -}}
-
-Allowed Value:
-
-- `{{ . }}`
-
-{{ end -}}
-{{ end -}}
-
 {{ define "DescriptionTpl" -}}
 {{ if . -}}
 
@@ -21,8 +11,10 @@ Allowed Value:
 
 Allowed Values:
 
-{{ . }}
+{{ range $enum := . -}}
 
+- {{ $enum }}
+{{ end -}}
 {{ end -}}
 {{ end -}}
 
@@ -45,9 +37,8 @@ Examples:
 {{ if . -}}
 | Property | Type | Required | Enum | Default | Description |
 | -------- | ---- | -------- | ---- | ------- | ----------- |
-{{ $propParent := . -}}
-{{ range $key, $prop := $propParent.Properties -}}
-| [`{{ $key }}`](#{{ $key }}) | {{ $prop.TypeInfoMarkdown }} | {{ if $propParent.RequiredKey $key }}✅{{ else }}➖{{ end }} | {{ if $prop.Enum }}✅{{ else }}➖{{ end }} | {{ $prop.Default.JSONString | wrapCode | default "➖" }} | {{ $prop.DescriptionMarkdown | stripMarkdown | firstSentence | toHTML }} |
+{{ range $key, $prop := .Properties -}}
+| [`{{ $prop.Key }}`](#{{ $prop.Key }}) | {{ $prop.TypeInfoMarkdown }} | {{ if $prop.Parent.RequiredKey $prop.Key }}✅{{ else }}➖{{ end }} | {{ if $prop.EnumMarkdownItems }}✅{{ else }}➖{{ end }} | {{ $prop.Default.JSONString | wrapCode | default "➖" }} | {{ $prop.DescriptionMarkdown | stripMarkdown | firstSentence | toHTML }} |
 {{ end -}}
 {{ end -}}
 {{ end -}}
@@ -55,9 +46,8 @@ Examples:
 # {{ .EntityName }}
 
 {{ template "DescriptionTpl" .DescriptionMarkdown }}
-{{ template "ConstTpl" .Const.String }}
-{{ template "EnumTpl" .EnumMarkdown }}
-{{ template "ExamplesTpl" .Examples }}
+{{ template "EnumTpl" .EnumMarkdownItems }}
+{{ template "ExamplesTpl" .YAMLExamples }}
 
 {{ if .OneOf -}}
 
@@ -75,16 +65,16 @@ Examples:
 {{ template "PropertiesTpl" . }}
 
 {{ end -}}
-{{ $root := . -}}
 {{ range $key, $prop := .Properties -}}
 
-### `{{ $key }}`
+### `{{ $prop.Key }}`
 
 | Type | Required | Enum | Default |
 | ---- | -------- | ---- | ------- |
-| {{ $prop.TypeInfoMarkdown }} | {{ if $root.RequiredKey $key }}✅{{ else }}➖{{ end }} | {{ if $prop.Enum }}✅{{ else }}➖{{ end }} | {{ $prop.Default.JSONString | wrapCode | default "➖" }} |
+| {{ $prop.TypeInfoMarkdown }} | {{ if $prop.Parent.RequiredKey $prop.Key }}✅{{ else }}➖{{ end }} | {{ if $prop.EnumMarkdownItems }}✅{{ else }}➖{{ end }} | {{ $prop.Default.JSONString | wrapCode | default "➖" }} |
 
 {{ template "DescriptionTpl" $prop.DescriptionMarkdown }}
+{{ template "EnumTpl" $prop.EnumMarkdownItems }}
 {{ template "ExamplesTpl" $prop.YAMLExamples }}
 
 {{ end -}}


### PR DESCRIPTION
- Show the property key in example YAML if present.
- Render enum values consistently as JSON.
- Treat `const` values as if they were a single item enum.